### PR TITLE
Autodetect Chip ID

### DIFF
--- a/breakouts.config
+++ b/breakouts.config
@@ -8,5 +8,7 @@
 0x29: vl53l1x-python: VL53L1X: vl53l1x time of flight
 0x33: mlx90640-library: mlx90460: mlx90640 thermal camera
 0x49: as7262-python: as7262: as7262 spectrometer
-0x76: bme680: bme680: bme680 weather sensor
-0x77: bme680: bme680: bme680 weather sensor
+0x76[0xd0=0x61]: bme680: bme680: bme680 weather sensor
+0x77[0xd0=0x61]: bme680: bme680: bme680 weather sensor
+0x76[0xd0=0x58]: bme280-python: bme280: bme280 temperature and pressure sensor
+0x77[0xd0=0x59]: bme280-python: bme280: bme280 temperature and pressure sensor

--- a/breakouts.config
+++ b/breakouts.config
@@ -10,5 +10,5 @@
 0x49: as7262-python: as7262: as7262 spectrometer
 0x76[0xd0=0x61]: bme680: bme680: bme680 weather sensor
 0x77[0xd0=0x61]: bme680: bme680: bme680 weather sensor
-0x76[0xd0=0x58]: bme280-python: bme280: bme280 temperature and pressure sensor
-0x77[0xd0=0x59]: bme280-python: bme280: bme280 temperature and pressure sensor
+0x76[0xd0=0x58]: bmp280-python: bmp280: bmp280 temperature and pressure sensor
+0x77[0xd0=0x59]: bmp280-python: bmp280: bmp280 temperature and pressure sensor


### PR DESCRIPTION
Added chip-ID register reads to disambiguate between hardware devices that share the same i2c address(es). This is primarily to determine the difference between BME680 and BMP280 but will also be needed forADS1015 to tell the difference between it and the as7262- possible enhancements needed to make that work.