### PR TITLE
Disambiguate PA1010D from VEML6075

### DIFF
--- a/autodetect.py
+++ b/autodetect.py
@@ -3,6 +3,7 @@ import smbus
 import sys
 
 I2C_BUS = 1
+DEBUG = False
 
 install_mode = False
 
@@ -16,12 +17,33 @@ except IOError:
     print("Unable to access /dev/i2c-{}, please ensure i2c is enabled!".format(I2C_BUS))
     sys.exit()
 
-def check_chip_id(i2cc_addr, chip_ids):
+
+def check_chip_id(i2c_addr, chip_ids):
+    if len(chip_ids) == 0:
+        return True
+
     for register in chip_ids:
-        value = chip_ids[register]
-        if value != bus.read_byte_data(i2c_addr, register):
-            return False
-    return True
+        value, size, negate_match = chip_ids[register]
+        reg, reg_size = register
+        if reg_size == 1:
+            if size == 1:
+                read = bus.read_byte_data(i2c_addr, reg)
+            elif size == 2:
+                read = bus.read_word_data(i2c_addr, reg)
+            else:
+                raise RuntimeError("Unsupported Chip ID size: {} byte(s)".format(size))
+
+            if negate_match and value != read:
+                return True
+            elif value == read:
+                return True
+
+        else:
+            # TODO: Support 16-bit registers
+            raise RuntimeError("Unsupported register size: {} byte(s)".format(size))
+
+    return False
+
 
 def get_device(line):
     parts=[x.strip() for x in line.split(":")]
@@ -33,16 +55,26 @@ def get_device(line):
     if(len(parts[0]) > 4):
         register_map = parts[0][5:-1].split(',')
         for mapping in register_map:
-            register, value = [int(x, 16) for x in mapping.split('=')]
-            chip_ids[register] = value
+            if '!=' in mapping:
+                register, value = [(int(x, 16), (len(x) - 2) // 2) for x in mapping.split('!=')]
+                chip_ids[register] = value[0], value[1], True
+            else:
+                register, value = [(int(x, 16), (len(x) - 2) // 2) for x in mapping.split('=')]
+                chip_ids[register] = value[0], value[1], False
 
     return i2c_addr, parts[1], parts[2], parts[3], chip_ids
 
 devices = [get_device(line) for line in open("breakouts.config").read().strip().split("\n")]
 
-addresses = [device[0] for device in devices]
+addresses = set([device[0] for device in devices])
+
 
 def identify(find_i2c_addr):
+    try:
+        bus.read_byte_data(find_i2c_addr, 0x00)
+    except IOError as e:
+        pass
+
     for i2c_addr, library, module, name, chip_ids in devices:
         if i2c_addr == find_i2c_addr and check_chip_id(i2c_addr, chip_ids):
             installed = True
@@ -51,7 +83,9 @@ def identify(find_i2c_addr):
             except ImportError:
                 installed = False
             return installed, library, name
+
     return None, None, None
+
 
 found_addr = []
 found_devices = {}
@@ -59,6 +93,7 @@ found_devices = {}
 for i2c_addr in addresses:
     try:
         bus.read_byte_data(i2c_addr, 0x00)
+        if DEBUG: print("Found device on: {:02x}".format(i2c_addr))
         found_addr.append(i2c_addr)
         installed, library, name = identify(i2c_addr)
         if installed is None:
@@ -67,7 +102,9 @@ for i2c_addr in addresses:
             found_devices[name] = [installed, library, [i2c_addr]]
         else:
             found_devices[name][2].append(i2c_addr)
+
     except IOError as e:
+        if DEBUG: print("IOError reading: {:02x}".format(i2c_addr))
         continue
 
 for name in found_devices:

--- a/breakouts.config
+++ b/breakouts.config
@@ -26,5 +26,6 @@
 0x77[0xd0=0x59]: bmp280-python: bmp280: bmp280 temperature and pressure sensor
 0x5a: drv2605-python: drv2605: drv2605 haptic driver
 0x26: msa301-python: msa301: msa3013-axis accelerometer
-0x10: veml6075-python: veml6075: veml6075 uva and uvb sensor
+0x10[0x0c=0x0026]: veml6075-python: veml6075: veml6075 uva and uvb sensor
+0x10[0x0c!=0x0026]: pa1010d-python: pa1010d: pa1010d GPS
 0x52: rv3028-python: rv3028: rv3028 real-time-clock breakout


### PR DESCRIPTION
Adds the ability to check 16-bit word-sized register values so it can read VEML6075s Chip ID.

Adds the ability to negate checks, so a device will only be detected if reg != value.

Should fix #25 